### PR TITLE
Added conversion from Jira to unified format

### DIFF
--- a/functions/common.ts
+++ b/functions/common.ts
@@ -1,8 +1,8 @@
-interface Assignee {
+export interface Assignee {
   name: string;
 }
 
-interface UnifiedIssue {
+export interface IUnifiedIssue {
   title: string;
   assignees: Assignee[];
   author: Assignee;
@@ -15,5 +15,5 @@ interface UnifiedIssue {
   projectID: number;
   dueDate: Date;
   labels: string[];
-  dependencies?: UnifiedIssue[];
+  dependencies?: IUnifiedIssue[];
 }

--- a/functions/jira/callAPI.ts
+++ b/functions/jira/callAPI.ts
@@ -9,7 +9,7 @@ const domainURL = (domainName: string) => `https://${domainName}.atlassian.net`;
  * @param operation - What HTTP method and Jira API endpoint to use
  * @param headers - Request headers
  * @param body - Optional Request body
- * @return response from the Jira API
+ * @returns response from the Jira API
  *
  * @example
  *    callAPI("iwanttotestthis", API_OPS.getIssues(projectKey), Headers.basicAuthHeader(token, email))

--- a/functions/jira/conversion.ts
+++ b/functions/jira/conversion.ts
@@ -1,0 +1,25 @@
+import { Assignee, IUnifiedIssue } from "../common";
+
+/**
+ * Convert Jira issue to unified format
+ * 
+ * @param issue - Jira issue
+ * @returns Jira issue in unified format
+ */
+export function toUnified(issue: any): IUnifiedIssue {
+  let unifiedIssue: IUnifiedIssue = {
+    title: issue.fields.summary,
+    assignees: ((name = issue.fields.assignee?.displayName) => (name ? [{ name: name } as Assignee] : []))(),
+    author: { name: issue.fields.creator.displayName },
+    body: issue.fields.description,
+    category: issue.fields.status.statusCategory.name,
+    statusChangeTime: new Date(issue.fields.statuscategorychangedate),
+    createdAt: new Date(issue.fields.created),
+    comments: issue.fields.comment.comments.map(comment => comment.body),
+    lastEditedAt: new Date(issue.fields.updated),
+    projectID: issue.fields.project.id,
+    dueDate: new Date(issue.fields.duedate),
+    labels: issue.fields.labels,
+  }
+  return unifiedIssue;
+}

--- a/functions/jira/conversion.ts
+++ b/functions/jira/conversion.ts
@@ -18,7 +18,7 @@ export function toUnified(issue: any): IUnifiedIssue {
     comments: issue.fields.comment.comments.map(comment => comment.body),
     lastEditedAt: new Date(issue.fields.updated),
     projectID: issue.fields.project.id,
-    dueDate: new Date(issue.fields.duedate),
+    dueDate: issue.fields.duedate ? new Date(issue.fields.duedate) : null,
     labels: issue.fields.labels,
   }
   return unifiedIssue;

--- a/functions/jira/index.ts
+++ b/functions/jira/index.ts
@@ -2,6 +2,7 @@ import { callAPI } from "./callAPI";
 import { API_OPS } from "./APIOperations";
 import { HEADERS } from "./header";
 import { Request, Response } from 'express'
+import { toUnified } from "./conversion"
 
 /**
  * Endpoint to get all issues for a Jira project
@@ -44,6 +45,9 @@ export default async (req: Request, res: Response) => {
     starting_issue += result.maxResults;
 
   } while ((result.startAt + result.maxResults) < result.total);
+
+  issues = issues.map(issue => toUnified(issue));
+
   res.status(200).send({ "num": issues.length, "issues": issues });
 }
 


### PR DESCRIPTION
Closes #19 

We realised that Jira does not give all information about its subtask/dependencies which means that dependencies will require a link to the actual issue and this link does not exist yet as we do not store it anywhere. We also need to discuss what to do about the project id as that has to be unique. Do we create our own or combine/re-use Jira/GitHub/Trello ids somehow? Either way, we think this can be done later when we implement the database.